### PR TITLE
fix(#13): Fix memory when systemStats are enabled

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -141,7 +141,7 @@ function sendUncompressedMessage(options, message, logger) {
  * @param aggregationFreq The aggregation frequency with which metric was aggregated.
  * @param parameters An object with metric para meters: tags, agg, aggFreq, namespace and timestamp.
  */
-function putMetric(self, metricTypeConf, name, value, aggregation, aggregationFreq, parameters, isStats) {
+function putMetric(self, metricTypeConf, name, value, aggregation, aggregationFreq, parameters) {
     var isMetricAggregated = aggregation && aggregationFreq;
     var metricParams = parameters || {};
     var tags = metricParams.tags,
@@ -156,21 +156,46 @@ function putMetric(self, metricTypeConf, name, value, aggregation, aggregationFr
             putTags = metricTypeConf ? merge(tags, metricTypeConf.tags) : tags,
             putAggFreq = metricTypeConf ? (aggFreq || metricTypeConf.aggFreq) : aggFreq;
 
-        putRaw(self, name, value, {tags: putTags, agg: putAgg, aggFreq: putAggFreq, namespace: namespace, timestamp: timestamp, sampleRate: sampleRate}, isMetricAggregated, isStats);
+        putRaw(self, name, value, {tags: putTags, agg: putAgg, aggFreq: putAggFreq, namespace: namespace, timestamp: timestamp, sampleRate: sampleRate}, isMetricAggregated);
     } else if (self.logger) {
         self.logger.warn('Metric not sent. Please review the following: aggregations, aggregation frequency, tags and timestamp.');
     }
 }
 
+/**
+ * Puts a system stats metric into the system stats buffer ready to be sent.
+ *
+ * @param self A self statful client.
+ * @param metricTypeConf A configuration for each metric type (counter, gauge, timer). Can be null if it a custom metric.
+ * @param name A metric name.
+ * @param value A metric value.
+ * @param aggregation The aggregation with which metric was aggregated.
+ * @param aggregationFreq The aggregation frequency with which metric was aggregated.
+ * @param parameters An object with metric para meters: tags, agg, aggFreq, namespace and timestamp.
+ */
+function putSystemStatsMetrics(self, name, value, parameters) {
+    var metricParams = parameters || {};
+    var tags = metricParams.tags,
+        agg =  metricParams.agg,
+        aggFreq = metricParams.aggFreq,
+        namespace = metricParams.namespace,
+        timestamp = metricParams.timestamp,
+        sampleRate = metricParams.sampleRate;
 
+    putSystemStats(self, name, value, {tags: tags, agg: agg, aggFreq: aggFreq, namespace: namespace, timestamp: timestamp, sampleRate: sampleRate});
+
+}
 
 function sendFlushStats(self) {
     if (self.systemStats) {
         if (self.aggregatedBuffer.bufferSize > 0 && self.transport === 'api') {
-            putMetric(self, null, 'buffer.flush_length', self.aggregatedBuffer.bufferSize, null, null, {agg: ['avg'], tags: {"buffer_type": 'aggregated'}}, true);
+            putSystemStatsMetrics(self, 'buffer.flush_length', self.aggregatedBuffer.bufferSize, {agg: ['avg', 'sum'], tags: {"buffer_type": 'aggregated'}});
         }
         if (self.nonAggregatedBuffer.bufferSize > 0) {
-            putMetric(self, null, 'buffer.flush_length', self.nonAggregatedBuffer.bufferSize, null, null, {agg: ['avg'], tags: {"buffer_type": 'non-aggregated'}}, true);
+            putSystemStatsMetrics(self, 'buffer.flush_length', self.nonAggregatedBuffer.bufferSize, {agg: ['avg', 'sum'], tags: {"buffer_type": 'non-aggregated'}});
+        }
+        if (self.nonAggregatedBuffer.bufferSize > 0) {
+            putSystemStatsMetrics(self, 'buffer.flush_length', self.systemStatsBuffer.bufferSize, {agg: ['avg', 'sum'], tags: {"buffer_type": 'system-stats'}});
         }
     }
 }
@@ -179,7 +204,6 @@ function sendFlushStats(self) {
  * Logs all the metrics to the logger
  *
  * @param self A self client instance.
-
  */
 function logMetrics(self) {
     var stringToLogHeader = '';
@@ -206,8 +230,8 @@ function logMetrics(self) {
         }
         self.logger.debug(stringToLogHeader + stringToLog);
     }
-    if (self.nonAggregatedStatsBuffer.bufferSize > 0) {
-        self.logger.debug('Flushing metrics (non aggregated): ' + self.nonAggregatedStatsBuffer.buffer);
+    if (self.systemStatsBuffer.bufferSize > 0) {
+        self.logger.debug('Flushing metrics (system stats): ' + self.systemStatsBuffer.buffer);
     }
 
     //in case we need to send aggregated stats metrics, add code here
@@ -215,10 +239,9 @@ function logMetrics(self) {
 }
 
 /**
- * Logs all the metrics to the logger
+ * Sends the non aggregated and system stats metrics using UDP transport
  *
  * @param self A self client instance.
-
  */
 function sendMetricsByUdpTransport(self) {
     var buffer;
@@ -238,19 +261,16 @@ function sendMetricsByUdpTransport(self) {
         self.socket.send(buffer, 0, buffer.length, self.port, self.host);
     }
 
-    //in case we need to send aggregated stats metrics, add code here
-
-    if (self.nonAggregatedStatsBuffer.bufferSize > 0) {
-        buffer = new Buffer(self.nonAggregatedStatsBuffer.buffer);
+    if (self.systemStatsBuffer.bufferSize > 0) {
+        buffer = new Buffer(self.systemStatsBuffer.buffer);
         self.socket.send(buffer, 0, buffer.length, self.port, self.host);
     }
 }
 
 /**
- * Logs all the metrics to the logger
+ * Sends all metrics using API transport
  *
  * @param self A self client instance.
-
  */
 function sendMetricsByApiTransport(self) {
     var agg;
@@ -294,22 +314,20 @@ function sendMetricsByApiTransport(self) {
         }
     }
 
-    if (self.nonAggregatedStatsBuffer.bufferSize > 0) {
+    if (self.systemStatsBuffer.bufferSize > 0) {
         var nonAggregatedStatsOptions = buildStatfulOptions(
             self.protocol, self.host, self.port, self.basePath, self.token, self.timeout);
 
         if (self.logger) {
-            self.logger.debug('Flushing to ' + nonAggregatedStatsOptions.url + ' non aggregated metrics');
+            self.logger.debug('Flushing to ' + nonAggregatedStatsOptions.url + ' system stats metrics');
         }
 
         if (self.compression) {
-            sendCompressedMessage(nonAggregatedStatsOptions, self.nonAggregatedStatsBuffer.buffer, self.logger);
+            sendCompressedMessage(nonAggregatedStatsOptions, self.systemStatsBuffer.buffer, self.logger);
         } else {
-            sendUncompressedMessage(nonAggregatedStatsOptions, self.nonAggregatedStatsBuffer.buffer, self.logger);
+            sendUncompressedMessage(nonAggregatedStatsOptions, self.systemStatsBuffer.buffer, self.logger);
         }
     }
-
-    //in case we need to send aggregated stats metrics, add code here
 }
 
 /**
@@ -340,8 +358,8 @@ function flush(self) {
         self.aggregatedBuffer.bufferSize = 0;
         self.nonAggregatedBuffer.buffer = '';
         self.nonAggregatedBuffer.bufferSize = 0;
-        self.nonAggregatedStatsBuffer.buffer = '';
-        self.nonAggregatedStatsBuffer.bufferSize = 0;
+        self.systemStatsBuffer.buffer = '';
+        self.systemStatsBuffer.bufferSize = 0;
 
     }
 }
@@ -377,7 +395,7 @@ function addToBuffer(self, metricLines, isMetricAggregated, agg, aggFreq) {
         }
 
 
-        if ( (self.aggregatedBuffer.bufferSize + self.nonAggregatedBuffer.bufferSize) >= self.flushSize) {
+        if ( (self.aggregatedBuffer.bufferSize + self.nonAggregatedBuffer.bufferSize + self.systemStatsBuffer.bufferSize) >= self.flushSize) {
             setTimeout(function() {
                 flush(self);
             }, 0);
@@ -394,30 +412,18 @@ function addToBuffer(self, metricLines, isMetricAggregated, agg, aggFreq) {
  *
  * @param self A self client instance.
  * @param metricLines The metrics, in valid line protocol, to push to the buffer.
- * @param isMetricAggregated A boolean state if metrics are aggregated.
- * @param agg In case that metric is aggregated we need to send the aggregation.
- * @param aggFreq In case that metric is aggregated we need to send the aggregation frequency.
  */
-function addToStatsBuffer(self, metricLines, isMetricAggregated, agg, aggFreq) {
+function addToStatsBuffer(self, metricLines) {
 
     if (typeof metricLines !== 'undefined') {
-        var targetBuffer = isMetricAggregated ? self.aggregatedStatsBuffer : self.nonAggregatedStatsBuffer;
+        var targetBuffer = self.systemStatsBuffer;
 
-        if (isMetricAggregated) {
-            if (targetBuffer[agg][aggFreq].buffer.length > 0) {
-                targetBuffer[agg][aggFreq].buffer += '\n';
-            }
-
-            targetBuffer[agg][aggFreq].buffer += metricLines;
-            targetBuffer.bufferSize++;
-        } else {
-            if (targetBuffer.bufferSize > 0) {
-                targetBuffer.buffer += '\n';
-            }
-
-            targetBuffer.buffer += metricLines;
-            targetBuffer.bufferSize++;
+        if (targetBuffer.bufferSize > 0) {
+            targetBuffer.buffer += '\n';
         }
+
+        targetBuffer.buffer += metricLines;
+        targetBuffer.bufferSize++;
 
     } else {
         if (self.logger) {
@@ -440,7 +446,7 @@ function addToStatsBuffer(self, metricLines, isMetricAggregated, agg, aggFreq) {
  *          - timestamp: Defines the metrics timestamp. Default: current timestamp.
  * @param isMetricAggregated
  */
-function putRaw(self, metric, value, parameters, isMetricAggregated, isStats) {
+function putRaw(self, metric, value, parameters, isMetricAggregated) {
     var metricParams = parameters || {};
 
     var tags = metricParams.tags,
@@ -476,17 +482,9 @@ function putRaw(self, metric, value, parameters, isMetricAggregated, isStats) {
         }
 
         if (!isMetricAggregated) {
-            if (!isStats) {
-                addToBuffer(self, [flushLine], isMetricAggregated, null, null);
-            } else {
-                addToStatsBuffer(self, [flushLine], isMetricAggregated, null, null);
-            }
+            addToBuffer(self, [flushLine], isMetricAggregated, null, null);
         } else {
-            if (!isStats) {
-                addToBuffer(self, [flushLine], isMetricAggregated, agg[0], putAggFreq);
-            } else {
-                addToStatsBuffer(self, [flushLine], isMetricAggregated, agg[0], putAggFreq);
-            }
+            addToBuffer(self, [flushLine], isMetricAggregated, agg[0], putAggFreq);
         }
     } else {
         if (self.logger) {
@@ -497,6 +495,64 @@ function putRaw(self, metric, value, parameters, isMetricAggregated, isStats) {
 }
 
 /**
+ * Adds a new system stats metric to the in-memory system stats buffer.
+ *
+ * @param self A self client instance.
+ * @param metric Name metric such as 'response_time'.
+ * @param value.
+ * @param parameters An object with metric para meters: tags, agg, aggFreq, namespace and timestamp.
+ *          - tags: Tags to associate this value with, for example {from: 'serviceA', to: 'serviceB', method: 'login'}.
+ *          - agg: List of aggregations to be applied by Statful. Ex: ['avg', 'p90', 'min'].
+ *          - aggFreq: Aggregation frequency in seconds. One of: 10, 30, 60 ,120, 180, 300. Default: 10.
+ *          - namespace: Define the metric namespace. Default: application.
+ *          - timestamp: Defines the metrics timestamp. Default: current timestamp.
+ */
+function putSystemStats(self, metric, value, parameters) {
+    var metricParams = parameters || {};
+
+    var tags = metricParams.tags,
+        agg = metricParams.agg,
+        aggFreq = metricParams.aggFreq,
+        namespace = metricParams.namespace,
+        timestamp = metricParams.timestamp,
+        sampleRate = parameters.sampleRate || self.sampleRate;
+
+    // Vars to Put
+    var putNamespace = namespace || self.namespace;
+    var putAggFreq = aggFreq || 10;
+    var putTags = merge(self.app ? merge({app: self.app}, tags) : tags, self.tags);
+
+    var metricName = putNamespace + '.' + metric,
+        flushLine = metricName,
+        sampleRateNormalized = (sampleRate || 100) / 100;
+
+    if (Math.random() <= sampleRateNormalized) {
+        flushLine = Object.keys(putTags).reduce(function (previousValue, tag) {
+            return previousValue + ',' + tag + '=' + putTags[tag];
+        }, flushLine);
+
+        flushLine += ' ' + value + ' ' + (timestamp || (Math.round(new Date().getTime() / 1000)));
+
+        if (agg) {
+            agg.push(putAggFreq);
+            flushLine += ' ' + agg.join(',');
+
+            if (sampleRate && sampleRate < 100) {
+                flushLine += ' ' + sampleRate;
+            }
+        }
+
+        addToStatsBuffer(self, [flushLine]);
+
+    } else {
+        if (self.logger) {
+            self.logger.warn('Metric was discarded due to sample rate.');
+        }
+    }
+
+}
+
+    /**
  * Calls put metric with an aggregated metric.
  *
  * @param self A self statful client.
@@ -508,7 +564,7 @@ function putRaw(self, metric, value, parameters, isMetricAggregated, isStats) {
  * @param parameters An object with metric para meters: tags, agg, aggFreq, namespace and timestamp.
  */
 function putAggregatedMetric(self, metricTypeConf, name, value, agg, aggFreq, parameters) {
-    putMetric(self, metricTypeConf, name, value, agg, aggFreq, parameters, false);
+    putMetric(self, metricTypeConf, name, value, agg, aggFreq, parameters);
 }
 
 /**
@@ -592,14 +648,14 @@ var Client = function (config, logger) {
         bufferSize: 0
     };
 
-    this.nonAggregatedStatsBuffer = {
+    this.systemStatsBuffer = {
         buffer: '',
         bufferSize: 0
     };
 
     if (this.systemStats) {
         blocked(function (ms) {
-            self.timer('event_loop', ms);
+            putSystemStatsMetrics(self, 'timer.event_loop', ms, {agg: ['avg', 'p90', 'count'], tags: {'unit': 'ms'}});
         });
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -158,7 +158,7 @@ function putMetric(self, metricTypeConf, name, value, aggregation, aggregationFr
 
         putRaw(self, name, value, {tags: putTags, agg: putAgg, aggFreq: putAggFreq, namespace: namespace, timestamp: timestamp, sampleRate: sampleRate}, isMetricAggregated);
     } else if (self.logger) {
-        self.logger.warn('Metric not sent. Please review the following: aggregations, aggregation frequency, tags and timestamp.');
+        self.logger.debug('Metric not sent. Please review the following: aggregations, aggregation frequency, tags and timestamp.');
     }
 }
 
@@ -546,7 +546,7 @@ function putSystemStats(self, metric, value, parameters) {
 
     } else {
         if (self.logger) {
-            self.logger.warn('Metric was discarded due to sample rate.');
+            self.logger.debug('Metric was discarded due to sample rate.');
         }
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,7 @@
 'use strict';
 
+//jshint latedef: nofunc
+
 var dgram = require('dgram'),
     blocked = require('blocked'),
     https = require('https'),
@@ -128,15 +130,186 @@ function sendUncompressedMessage(options, message, logger) {
     performRequest(options, logger);
 }
 
+/**
+ * Puts a metric into the buffer ready to be sent.
+ *
+ * @param self A self statful client.
+ * @param metricTypeConf A configuration for each metric type (counter, gauge, timer). Can be null if it a custom metric.
+ * @param name A metric name.
+ * @param value A metric value.
+ * @param aggregation The aggregation with which metric was aggregated.
+ * @param aggregationFreq The aggregation frequency with which metric was aggregated.
+ * @param parameters An object with metric para meters: tags, agg, aggFreq, namespace and timestamp.
+ */
+function putMetric(self, metricTypeConf, name, value, aggregation, aggregationFreq, parameters, isStats) {
+    var isMetricAggregated = aggregation && aggregationFreq;
+    var metricParams = parameters || {};
+    var tags = metricParams.tags,
+        agg = !isMetricAggregated ? metricParams.agg : [aggregation],
+        aggFreq = !isMetricAggregated ? metricParams.aggFreq : aggregationFreq,
+        namespace = metricParams.namespace,
+        timestamp = metricParams.timestamp,
+        sampleRate = metricParams.sampleRate;
+
+    if (configHelper.areMetricTypesArgumentsValid(agg, aggFreq, tags, timestamp)) {
+        var putAgg = metricTypeConf ? configHelper.concatAggregations(metricTypeConf.agg, agg) : agg,
+            putTags = metricTypeConf ? merge(tags, metricTypeConf.tags) : tags,
+            putAggFreq = metricTypeConf ? (aggFreq || metricTypeConf.aggFreq) : aggFreq;
+
+        putRaw(self, name, value, {tags: putTags, agg: putAgg, aggFreq: putAggFreq, namespace: namespace, timestamp: timestamp, sampleRate: sampleRate}, isMetricAggregated, isStats);
+    } else if (self.logger) {
+        self.logger.warn('Metric not sent. Please review the following: aggregations, aggregation frequency, tags and timestamp.');
+    }
+}
+
+
+
 function sendFlushStats(self) {
     if (self.systemStats) {
         if (self.aggregatedBuffer.bufferSize > 0 && self.transport === 'api') {
-            self.put('buffer.flush_length', self.aggregatedBuffer.bufferSize, {agg: ['avg'], tags: {"buffer_type": 'aggregated'}});
+            putMetric(self, null, 'buffer.flush_length', self.aggregatedBuffer.bufferSize, null, null, {agg: ['avg'], tags: {"buffer_type": 'aggregated'}}, true);
         }
         if (self.nonAggregatedBuffer.bufferSize > 0) {
-            self.put('buffer.flush_length', self.nonAggregatedBuffer.bufferSize, {agg: ['avg'], tags: {"buffer_type": 'non-aggregated'}});
+            putMetric(self, null, 'buffer.flush_length', self.nonAggregatedBuffer.bufferSize, null, null, {agg: ['avg'], tags: {"buffer_type": 'non-aggregated'}}, true);
         }
     }
+}
+
+/**
+ * Logs all the metrics to the logger
+ *
+ * @param self A self client instance.
+
+ */
+function logMetrics(self) {
+    var stringToLogHeader = '';
+    var stringToLog = '';
+    var aggLog;
+    var aggFreqLog;
+
+    if (self.nonAggregatedBuffer.bufferSize > 0) {
+        self.logger.debug('Flushing metrics (non aggregated): ' + self.nonAggregatedBuffer.buffer);
+    }
+    if (self.aggregatedBuffer.bufferSize > 0) {
+        stringToLogHeader = 'Flushing metrics (aggregated): ';
+
+        for (aggLog in self.aggregatedBuffer) {
+            for (aggFreqLog in self.aggregatedBuffer[aggLog]) {
+                if (self.aggregatedBuffer[aggLog][aggFreqLog].buffer.length > 0) {
+                    if (stringToLog.length > 0) {
+                        stringToLog +='\n';
+                    }
+                    stringToLog += self.aggregatedBuffer[aggLog][aggFreqLog].buffer;
+                    self.aggregatedBuffer[aggLog][aggFreqLog].buffer = '';
+                }
+            }
+        }
+        self.logger.debug(stringToLogHeader + stringToLog);
+    }
+    if (self.nonAggregatedStatsBuffer.bufferSize > 0) {
+        self.logger.debug('Flushing metrics (non aggregated): ' + self.nonAggregatedStatsBuffer.buffer);
+    }
+
+    //in case we need to send aggregated stats metrics, add code here
+
+}
+
+/**
+ * Logs all the metrics to the logger
+ *
+ * @param self A self client instance.
+
+ */
+function sendMetricsByUdpTransport(self) {
+    var buffer;
+    if (self.logger) {
+        self.logger.debug('Flushing to ' + self.host + ', UDP port: ' + self.port);
+    }
+
+    if (self.aggregatedBuffer.bufferSize > 0) {
+        if (self.logger) {
+            self.logger.debug('Can\'t flush aggregated metrics using udp transport.');
+        }
+        self.aggregatedBuffer = configHelper.createEmptyAggregatedBuffer();
+    }
+
+    if (self.nonAggregatedBuffer.bufferSize > 0) {
+        buffer = new Buffer(self.nonAggregatedBuffer.buffer);
+        self.socket.send(buffer, 0, buffer.length, self.port, self.host);
+    }
+
+    //in case we need to send aggregated stats metrics, add code here
+
+    if (self.nonAggregatedStatsBuffer.bufferSize > 0) {
+        buffer = new Buffer(self.nonAggregatedStatsBuffer.buffer);
+        self.socket.send(buffer, 0, buffer.length, self.port, self.host);
+    }
+}
+
+/**
+ * Logs all the metrics to the logger
+ *
+ * @param self A self client instance.
+
+ */
+function sendMetricsByApiTransport(self) {
+    var agg;
+    var aggFreq;
+
+    if (self.nonAggregatedBuffer.bufferSize > 0) {
+        var nonAggregatedOptions = buildStatfulOptions(
+            self.protocol, self.host, self.port, self.basePath, self.token, self.timeout);
+
+        if (self.logger) {
+            self.logger.debug('Flushing to ' + nonAggregatedOptions.url + ' non aggregated metrics');
+        }
+
+        if (self.compression) {
+            sendCompressedMessage(nonAggregatedOptions, self.nonAggregatedBuffer.buffer, self.logger);
+        } else {
+            sendUncompressedMessage(nonAggregatedOptions, self.nonAggregatedBuffer.buffer, self.logger);
+        }
+    }
+
+    if (self.aggregatedBuffer.bufferSize > 0) {
+        for (agg in self.aggregatedBuffer) {
+            for (aggFreq in self.aggregatedBuffer[agg]) {
+                if (self.aggregatedBuffer[agg][aggFreq].buffer.length > 0) {
+                    var aggregatedPath = self.basePath + '/aggregation/' + agg + '/frequency/' + aggFreq;
+                    var aggregatedOptions = buildStatfulOptions(
+                        self.protocol, self.host, self.port, aggregatedPath, self.token, self.timeout);
+
+                    if (self.logger) {
+                        self.logger.debug('Flushing to ' + aggregatedOptions.url + ' aggregated metrics');
+                    }
+
+                    if (self.compression) {
+                        sendCompressedMessage(aggregatedOptions, self.aggregatedBuffer[agg][aggFreq].buffer, self.logger);
+                    } else {
+                        sendUncompressedMessage(aggregatedOptions, self.aggregatedBuffer[agg][aggFreq].buffer, self.logger);
+                    }
+                    self.aggregatedBuffer[agg][aggFreq].buffer = '';
+                }
+            }
+        }
+    }
+
+    if (self.nonAggregatedStatsBuffer.bufferSize > 0) {
+        var nonAggregatedStatsOptions = buildStatfulOptions(
+            self.protocol, self.host, self.port, self.basePath, self.token, self.timeout);
+
+        if (self.logger) {
+            self.logger.debug('Flushing to ' + nonAggregatedStatsOptions.url + ' non aggregated metrics');
+        }
+
+        if (self.compression) {
+            sendCompressedMessage(nonAggregatedStatsOptions, self.nonAggregatedStatsBuffer.buffer, self.logger);
+        } else {
+            sendUncompressedMessage(nonAggregatedStatsOptions, self.nonAggregatedStatsBuffer.buffer, self.logger);
+        }
+    }
+
+    //in case we need to send aggregated stats metrics, add code here
 }
 
 /**
@@ -145,92 +318,21 @@ function sendFlushStats(self) {
  * @param self A self client instance.
  */
 function flush(self) {
-    var buffer;
 
     sendFlushStats(self);
 
     if ( (self.aggregatedBuffer.bufferSize + self.nonAggregatedBuffer.bufferSize) > 0) {
         if (self.dryRun) {
             if (self.logger) {
-                if (self.nonAggregatedBuffer.bufferSize > 0) {
-                    self.logger.debug('Flushing metrics (non aggregated): ' + self.nonAggregatedBuffer.buffer);
-                }
-                if (self.aggregatedBuffer.bufferSize > 0) {
-                    var stringToLogHeader = 'Flushing metrics (aggregated): ';
-                    var stringToLog = '';
-
-
-                    for (var aggLog in self.aggregatedBuffer) {
-                        for (var aggFreqLog in self.aggregatedBuffer[aggLog]) {
-                            if (self.aggregatedBuffer[aggLog][aggFreqLog].buffer.length > 0) {
-                                if (stringToLog.length > 0) {
-                                    stringToLog +='\n';
-                                }
-                                stringToLog += self.aggregatedBuffer[aggLog][aggFreqLog].buffer;
-                                self.aggregatedBuffer[aggLog][aggFreqLog].buffer = '';
-                            }
-                        }
-                    }
-                    self.logger.debug(stringToLogHeader + stringToLog);
-                }
+                logMetrics(self);
             }
         } else {
             switch (self.transport) {
                 case 'udp':
-                    if (self.logger) {
-                        self.logger.debug('Flushing to ' + self.host + ', UDP port: ' + self.port);
-                    }
-
-                    if (self.aggregatedBuffer.bufferSize > 0) {
-                        if (self.logger) {
-                            self.logger.debug('Can\'t flush aggregated metrics using udp transport.');
-                        }
-                        self.aggregatedBuffer = configHelper.createEmptyAggregatedBuffer();
-                    }
-
-                    if (self.nonAggregatedBuffer.bufferSize > 0) {
-                        buffer = new Buffer(self.nonAggregatedBuffer.buffer);
-                        self.socket.send(buffer, 0, buffer.length, self.port, self.host);
-                    }
+                    sendMetricsByUdpTransport(self);
                     break;
                 case 'api':
-                    if (self.nonAggregatedBuffer.bufferSize > 0) {
-                        var nonAggregatedOptions = buildStatfulOptions(
-                            self.protocol, self.host, self.port, self.basePath, self.token, self.timeout);
-
-                        if (self.logger) {
-                            self.logger.debug('Flushing to ' + nonAggregatedOptions.url + ' non aggregated metrics');
-                        }
-
-                        if (self.compression) {
-                            sendCompressedMessage(nonAggregatedOptions, self.nonAggregatedBuffer.buffer, self.logger);
-                        } else {
-                            sendUncompressedMessage(nonAggregatedOptions, self.nonAggregatedBuffer.buffer, self.logger);
-                        }
-                    }
-
-                    if (self.aggregatedBuffer.bufferSize > 0) {
-                        for (var agg in self.aggregatedBuffer) {
-                            for (var aggFreq in self.aggregatedBuffer[agg]) {
-                                if (self.aggregatedBuffer[agg][aggFreq].buffer.length > 0) {
-                                    var aggregatedPath = self.basePath + '/aggregation/' + agg + '/frequency/' + aggFreq;
-                                    var aggregatedOptions = buildStatfulOptions(
-                                        self.protocol, self.host, self.port, aggregatedPath, self.token, self.timeout);
-
-                                    if (self.logger) {
-                                        self.logger.debug('Flushing to ' + aggregatedOptions.url + ' aggregated metrics');
-                                    }
-
-                                    if (self.compression) {
-                                        sendCompressedMessage(aggregatedOptions, self.aggregatedBuffer[agg][aggFreq].buffer, self.logger);
-                                    } else {
-                                        sendUncompressedMessage(aggregatedOptions, self.aggregatedBuffer[agg][aggFreq].buffer, self.logger);
-                                    }
-                                    self.aggregatedBuffer[agg][aggFreq].buffer = '';
-                                }
-                            }
-                        }
-                    }
+                    sendMetricsByApiTransport(self);
                     break;
             }
         }
@@ -238,6 +340,9 @@ function flush(self) {
         self.aggregatedBuffer.bufferSize = 0;
         self.nonAggregatedBuffer.buffer = '';
         self.nonAggregatedBuffer.bufferSize = 0;
+        self.nonAggregatedStatsBuffer.buffer = '';
+        self.nonAggregatedStatsBuffer.bufferSize = 0;
+
     }
 }
 
@@ -285,6 +390,43 @@ function addToBuffer(self, metricLines, isMetricAggregated, agg, aggFreq) {
 }
 
 /**
+ * Adds raw metrics directly into the flush buffer. Use this method with caution.
+ *
+ * @param self A self client instance.
+ * @param metricLines The metrics, in valid line protocol, to push to the buffer.
+ * @param isMetricAggregated A boolean state if metrics are aggregated.
+ * @param agg In case that metric is aggregated we need to send the aggregation.
+ * @param aggFreq In case that metric is aggregated we need to send the aggregation frequency.
+ */
+function addToStatsBuffer(self, metricLines, isMetricAggregated, agg, aggFreq) {
+
+    if (typeof metricLines !== 'undefined') {
+        var targetBuffer = isMetricAggregated ? self.aggregatedStatsBuffer : self.nonAggregatedStatsBuffer;
+
+        if (isMetricAggregated) {
+            if (targetBuffer[agg][aggFreq].buffer.length > 0) {
+                targetBuffer[agg][aggFreq].buffer += '\n';
+            }
+
+            targetBuffer[agg][aggFreq].buffer += metricLines;
+            targetBuffer.bufferSize++;
+        } else {
+            if (targetBuffer.bufferSize > 0) {
+                targetBuffer.buffer += '\n';
+            }
+
+            targetBuffer.buffer += metricLines;
+            targetBuffer.bufferSize++;
+        }
+
+    } else {
+        if (self.logger) {
+            self.logger.error('Invalid metric lines: ' + metricLines);
+        }
+    }
+}
+
+/**
  * Adds a new metric to the in-memory buffer.
  *
  * @param self A self client instance.
@@ -298,7 +440,7 @@ function addToBuffer(self, metricLines, isMetricAggregated, agg, aggFreq) {
  *          - timestamp: Defines the metrics timestamp. Default: current timestamp.
  * @param isMetricAggregated
  */
-function putRaw(self, metric, value, parameters, isMetricAggregated) {
+function putRaw(self, metric, value, parameters, isMetricAggregated, isStats) {
     var metricParams = parameters || {};
 
     var tags = metricParams.tags,
@@ -334,9 +476,17 @@ function putRaw(self, metric, value, parameters, isMetricAggregated) {
         }
 
         if (!isMetricAggregated) {
-            addToBuffer(self, [flushLine], isMetricAggregated, null, null);
+            if (!isStats) {
+                addToBuffer(self, [flushLine], isMetricAggregated, null, null);
+            } else {
+                addToStatsBuffer(self, [flushLine], isMetricAggregated, null, null);
+            }
         } else {
-            addToBuffer(self, [flushLine], isMetricAggregated, agg[0], putAggFreq);
+            if (!isStats) {
+                addToBuffer(self, [flushLine], isMetricAggregated, agg[0], putAggFreq);
+            } else {
+                addToStatsBuffer(self, [flushLine], isMetricAggregated, agg[0], putAggFreq);
+            }
         }
     } else {
         if (self.logger) {
@@ -344,38 +494,6 @@ function putRaw(self, metric, value, parameters, isMetricAggregated) {
         }
     }
 
-}
-
-/**
- * Puts a metric into the buffer ready to be sent.
- *
- * @param self A self statful client.
- * @param metricTypeConf A configuration for each metric type (counter, gauge, timer). Can be null if it a custom metric.
- * @param name A metric name.
- * @param value A metric value.
- * @param aggregation The aggregation with which metric was aggregated.
- * @param aggregationFreq The aggregation frequency with which metric was aggregated.
- * @param parameters An object with metric para meters: tags, agg, aggFreq, namespace and timestamp.
- */
-function putMetric(self, metricTypeConf, name, value, aggregation, aggregationFreq, parameters) {
-    var isMetricAggregated = aggregation && aggregationFreq;
-    var metricParams = parameters || {};
-    var tags = metricParams.tags,
-        agg = !isMetricAggregated ? metricParams.agg : [aggregation],
-        aggFreq = !isMetricAggregated ? metricParams.aggFreq : aggregationFreq,
-        namespace = metricParams.namespace,
-        timestamp = metricParams.timestamp,
-        sampleRate = metricParams.sampleRate;
-
-    if (configHelper.areMetricTypesArgumentsValid(agg, aggFreq, tags, timestamp)) {
-        var putAgg = metricTypeConf ? configHelper.concatAggregations(metricTypeConf.agg, agg) : agg,
-            putTags = metricTypeConf ? merge(tags, metricTypeConf.tags) : tags,
-            putAggFreq = metricTypeConf ? (aggFreq || metricTypeConf.aggFreq) : aggFreq;
-
-        putRaw(self, name, value, {tags: putTags, agg: putAgg, aggFreq: putAggFreq, namespace: namespace, timestamp: timestamp, sampleRate: sampleRate}, isMetricAggregated);
-    } else if (self.logger) {
-        self.logger.warn('Metric not sent. Please review the following: aggregations, aggregation frequency, tags and timestamp.');
-    }
 }
 
 /**
@@ -390,7 +508,7 @@ function putMetric(self, metricTypeConf, name, value, aggregation, aggregationFr
  * @param parameters An object with metric para meters: tags, agg, aggFreq, namespace and timestamp.
  */
 function putAggregatedMetric(self, metricTypeConf, name, value, agg, aggFreq, parameters) {
-    putMetric(self, metricTypeConf, name, value, agg, aggFreq, parameters);
+    putMetric(self, metricTypeConf, name, value, agg, aggFreq, parameters, false);
 }
 
 /**
@@ -403,7 +521,7 @@ function putAggregatedMetric(self, metricTypeConf, name, value, agg, aggFreq, pa
  * @param parameters An object with metric para meters: tags, agg, aggFreq, namespace and timestamp.
  */
 function putNonAggregatedMetric(self, metricTypeConf, name, value, parameters) {
-    putMetric(self, metricTypeConf, name, value, null, null, parameters);
+    putMetric(self, metricTypeConf, name, value, null, null, parameters, false);
 }
 
 /**
@@ -470,6 +588,11 @@ var Client = function (config, logger) {
     this.aggregatedBuffer = configHelper.createEmptyAggregatedBuffer();
 
     this.nonAggregatedBuffer = {
+        buffer: '',
+        bufferSize: 0
+    };
+
+    this.nonAggregatedStatsBuffer = {
         buffer: '',
         bufferSize: 0
     };

--- a/spec/common.spec.js
+++ b/spec/common.spec.js
@@ -44,7 +44,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             udpServer.stop();
 
-            expect(lines.toString()).to.match(/^application.my_metric 1 \d+$/);
+            expect(lines.toString()).to.match(/^application\.my_metric 1 \d+$/);
             done();
         }
     });
@@ -68,7 +68,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             udpServer.stop();
 
-            expect(lines.toString()).to.match(/^application.my_metric1 1 \d+\napplication.my_metric2 1 \d+$/);
+            expect(lines.toString()).to.match(/^application\.my_metric1 1 \d+\napplication\.my_metric2 1 \d+$/);
             done();
         }
     });
@@ -91,7 +91,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             httpsServer.stop();
 
-            expect(lines).to.match(/^application.my_metric 1 \d+$/);
+            expect(lines).to.match(/^application\.my_metric 1 \d+$/);
             done();
         }
     });
@@ -115,7 +115,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             httpsServer.stop();
 
-            expect(lines).to.match(/^application.my_metric 1 \d+$/);
+            expect(lines).to.match(/^application\.my_metric 1 \d+$/);
             done();
         }
     });
@@ -139,7 +139,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             httpsServer.stop();
 
-            expect(lines).to.match(/^application.my_metric1 1 \d+\napplication.my_metric2 1 \d+$/);
+            expect(lines).to.match(/^application\.my_metric1 1 \d+\napplication\.my_metric2 1 \d+$/);
             done();
         }
     });
@@ -162,7 +162,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             udpServer.stop();
 
-            expect(lines.toString()).to.match(/^application.my_metric 1 \d+$/);
+            expect(lines.toString()).to.match(/^application\.my_metric 1 \d+$/);
             done();
         }
     });
@@ -185,7 +185,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             udpServer.stop();
 
-            expect(lines.toString()).to.match(/^my_namespace.my_metric 1 \d+$/);
+            expect(lines.toString()).to.match(/^my_namespace\.my_metric 1 \d+$/);
             done();
         }
     });
@@ -258,7 +258,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             udpServer.stop();
             randomStub.restore();
-            expect(lines.toString()).to.match(/^application.my_metric 1 \d+ avg,10 80$/);
+            expect(lines.toString()).to.match(/^application\.my_metric 1 \d+ avg,10 80$/);
             done();
         }
     });
@@ -353,7 +353,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             httpsServer.stop();
 
-            expect(lines).to.match(/^application.my_metric 1 \d+$/);
+            expect(lines).to.match(/^application\.my_metric 1 \d+$/);
             done();
         }
     });
@@ -392,7 +392,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             udpServer.stop();
 
-            expect(lines.toString()).to.match(/^my_namespace.my_metric 1 \d+$/);
+            expect(lines.toString()).to.match(/^my_namespace\.my_metric 1 \d+$/);
             done();
         }
     });
@@ -416,7 +416,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             udpServer.stop();
 
-            expect(lines.toString()).to.match(/^my_other_namespace.my_metric 1 \d+$/);
+            expect(lines.toString()).to.match(/^my_other_namespace\.my_metric 1 \d+$/);
             done();
         }
     });
@@ -463,7 +463,7 @@ describe('When sending metrics', function () {
         function onResponse(lines) {
             udpServer.stop();
 
-            expect(lines.toString()).to.match(/^application.my_metric 1 \d+$/);
+            expect(lines.toString()).to.match(/^application\.my_metric 1 \d+$/);
             done();
         }
     });
@@ -535,7 +535,7 @@ describe('When sending metrics', function () {
     it('should log metrics when dryRun is activated (non aggregated metrics)', function (done) {
         // Given
         var victim = new Client({
-            systemStats: true,
+            systemStats: false,
             transport: 'api',
             api: apiConf,
             flushSize: 1,
@@ -549,8 +549,7 @@ describe('When sending metrics', function () {
 
         // Then
         setTimeout(function () {
-            expect(victim.logger.debug.getCall(0).args[0]).to.match(/^Flushing metrics \(non aggregated\): application.my_metric 1 \d+$/);
-            expect(victim.logger.debug.getCall(1).args[0]).to.match(/^Flushing metrics \(non aggregated\): application.buffer.flush_length,buffer_type=non-aggregated 1 \d+ avg,10$/);
+            expect(victim.logger.debug.getCall(0).args[0]).to.match(/^Flushing metrics \(non aggregated\): application\.my_metric 1 \d+$/);
             victim.logger.debug.restore();
             done();
         });
@@ -560,7 +559,7 @@ describe('When sending metrics', function () {
     it('should log metrics when dryRun is activated (aggregated)', function (done) {
         // Given
         var victim = new Client({
-            systemStats: true,
+            systemStats: false,
             transport: 'api',
             api: apiConf,
             flushSize: 2,
@@ -576,8 +575,7 @@ describe('When sending metrics', function () {
 
         // Then
         setTimeout(function () {
-            expect(victim.logger.debug.getCall(0).args[0]).to.match(/^Flushing metrics \(aggregated\): application.my_metric 1 \d+\napplication\.my_metric 1 \d+$/);
-            expect(victim.logger.debug.getCall(1).args[0]).to.match(/^Flushing metrics \(non aggregated\): application.buffer.flush_length,buffer_type=aggregated 2 \d+ avg,10$/);
+            expect(victim.logger.debug.getCall(0).args[0]).to.match(/^Flushing metrics \(aggregated\): application\.my_metric 1 \d+\napplication\.my_metric 1 \d+$/);
             victim.logger.debug.restore();
             done();
         });
@@ -587,7 +585,7 @@ describe('When sending metrics', function () {
     it('should log metrics when dryRun is activated (aggregated and non aggregated metrics)', function (done) {
         // Given
         var victim = new Client({
-            systemStats: true,
+            systemStats: false,
             transport: 'api',
             api: apiConf,
             flushSize: 3,
@@ -603,9 +601,8 @@ describe('When sending metrics', function () {
 
         // Then
         setTimeout(function () {
-            expect(victim.logger.debug.getCall(0).args[0]).to.match(/^Flushing metrics \(non aggregated\): application.my_metric 1 \d+$/);
-            expect(victim.logger.debug.getCall(1).args[0]).to.match(/^Flushing metrics \(aggregated\): application.my_metric 1 \d+\napplication\.my_metric 1 \d+$/);
-            expect(victim.logger.debug.getCall(2).args[0]).to.match(/^Flushing metrics \(non aggregated\): application.buffer.flush_length,buffer_type=aggregated 2 \d+ avg,10\napplication.buffer.flush_length,buffer_type=non-aggregated 1 \d+ avg,10$/);
+            expect(victim.logger.debug.getCall(0).args[0]).to.match(/^Flushing metrics \(non aggregated\): application\.my_metric 1 \d+$/);
+            expect(victim.logger.debug.getCall(1).args[0]).to.match(/^Flushing metrics \(aggregated\): application\.my_metric 1 \d+\napplication\.my_metric 1 \d+$/);
             victim.logger.debug.restore();
             done();
         });
@@ -630,6 +627,7 @@ describe('When sending metrics', function () {
         setTimeout(function () {
             expect(victim.logger.debug.getCall(1).args[0]).to.be.equal('Can\'t flush aggregated metrics using udp transport.');
             expect(victim.aggregatedBuffer.bufferSize).to.be.equal(0);
+            victim.logger.debug.restore();
             done();
         });
 
@@ -640,13 +638,11 @@ describe('When sending metrics', function () {
         httpsServer.start(httpPort, '127.0.0.1', onResponse);
 
         var victim = new Client({
-            systemStats: true,
+            systemStats: false,
             transport: 'api',
             api: apiConf,
             flushSize: 2
         }, logger);
-
-        var counter = 0;
 
         // When
         victim.aggregatedPut('my_metric1', 1, 'avg', 60);
@@ -655,13 +651,8 @@ describe('When sending metrics', function () {
         // Then
         function onResponse(lines) {
             httpsServer.stop();
-            if (counter === 0) {
-                expect(lines.toString()).to.match(/^application\.my_metric1 1 \d+\napplication\.my_metric2 1 \d+$/);
-                counter ++;
-            } else {
-                expect(lines.toString()).to.match(/^application.buffer.flush_length,buffer_type=aggregated 2 \d+ avg,10$/);
-                done();
-            }
+            expect(lines.toString()).to.match(/^application\.my_metric1 1 \d+\napplication\.my_metric2 1 \d+$/);
+            done();
         }
     });
 
@@ -670,14 +661,12 @@ describe('When sending metrics', function () {
         httpsServer.start(httpPort, '127.0.0.1', onResponse, 201, true);
 
         var victim = new Client({
-            systemStats: true,
+            systemStats: false,
             transport: 'api',
             api: apiConf,
             compression: true,
             flushSize: 2
         }, logger);
-
-        var counter = 0;
 
         // When
         victim.aggregatedPut('my_metric1', 1, 'avg', 60);
@@ -686,14 +675,10 @@ describe('When sending metrics', function () {
         // Then
         function onResponse(lines) {
             httpsServer.stop();
-            if (counter === 0) {
-                expect(lines.toString()).to.match(/^application\.my_metric1 1 \d+\napplication\.my_metric2 1 \d+$/);
-                counter++;
-            } else {
-                expect(lines.toString()).to.match(/^application.buffer.flush_length,buffer_type=aggregated 2 \d+ avg,10$/);
-                done();
-            }
 
+            expect(lines.toString()).to.match(/^application\.my_metric1 1 \d+\napplication\.my_metric2 1 \d+$/);
+
+            done();
         }
     });
 
@@ -702,13 +687,11 @@ describe('When sending metrics', function () {
         httpsServer.start(httpPort, '127.0.0.1', onResponse);
 
         var victim = new Client({
-            systemStats: true,
+            systemStats: false,
             transport: 'api',
             api: apiConf,
             flushSize: 2
         }, logger);
-
-        var counter = 0;
 
         // When
         victim.aggregatedPut('my_metric1', 1, 'avg', 60);
@@ -717,13 +700,8 @@ describe('When sending metrics', function () {
         // Then
         function onResponse(lines) {
             httpsServer.stop();
-            if (counter === 0) {
-                expect(lines.toString()).to.match(/^application\.my_metric1 1 \d+\napplication\.my_metric2 1 \d+$/);
-                counter++;
-            } else {
-                expect(lines.toString()).to.match(/^application.buffer.flush_length,buffer_type=aggregated 2 \d+ avg,10$/);
-                done();
-            }
+            expect(lines.toString()).to.match(/^application\.my_metric1 1 \d+\napplication\.my_metric2 1 \d+$/);
+            done();
         }
     });
 
@@ -802,4 +780,90 @@ describe('When sending metrics', function () {
         expect(victim.aggregatedBuffer.bufferSize).to.be.equal(0);
         done();
     });
+
+    it('should send system stats metrics through UDP', function (done) {
+        // Given
+        udpServer.start(udpPort, '127.0.0.1', null, onResponse);
+
+        var victim = new Client({
+            systemStats: true,
+            transport: 'udp',
+            port: udpPort,
+            flushSize: 1,
+            flushInterval: 10000
+        }, logger);
+
+        // When
+        victim.put('my_metric', 1, null, false);
+
+        // Then
+        function onResponse(lines) {
+            //expect my_metric
+            if (lines.toString().indexOf("\n") === -1) {
+                expect(lines.toString()).to.match(/^application.my_metric 1 \d+$/);
+            } else {
+                //expect systemStats after that
+                expect(lines.toString()).to.match(/^application\.buffer\.flush_length,buffer_type=non_aggregated 1 \d+$/);
+                udpServer.stop();
+            }
+
+            done();
+        }
+    });
+
+
+    it('should log metrics when dryRun is activated (systemStats)', function (done) {
+        // Given
+        var victim = new Client({
+            systemStats: true,
+            transport: 'api',
+            api: apiConf,
+            flushSize: 1,
+            dryRun: true
+        }, logger);
+
+        sinon.spy(victim.logger, "debug");
+
+        // When
+        victim.put('my_metric', 1);
+
+        // Then
+        setTimeout(function () {
+            expect(victim.logger.debug.getCall(1).args[0]).to.match(/^Flushing metrics \(system stats\): application\.buffer\.flush_length,buffer_type=non-aggregated 1 \d+ avg,sum,10\napplication\.buffer\.flush_length,buffer_type=system-stats 1 \d+ avg,sum,10/);
+
+            victim.logger.debug.restore();
+            done();
+        });
+
+    });
+
+    it('should send system stats metrics through HTTPS', function (done) {
+        // Given
+        httpsServer.start(httpPort, '127.0.0.1', onResponse);
+
+        var victim = new Client({
+            systemStats: true,
+            transport: 'api',
+            api: apiConf,
+            flushSize: 1
+        }, logger);
+
+        // When
+        victim.put('my_metric', 1);
+
+        // Then
+        function onResponse(lines) {
+
+            if (lines.toString().indexOf("\n") === -1) {
+                expect(lines).to.match(/^application\.my_metric 1 \d+$/);
+
+            } else {
+                expect(lines).to.match(/^Flushing metrics \(system stats\): application\.buffer\.flush_length,buffer_type=aggregated 1 \d+ avg,10\napplication\.buffer\.flush_length,buffer_type=system-stats 1 \d+ avg,10/);
+                httpsServer.stop();
+            }
+
+            done();
+        }
+    });
+
 });


### PR DESCRIPTION
- Fixed loop when systemStats are enabled
- Added a non aggregated stats buffer to send this metrics
- Functions that are exposed in the client object didn't change at all
  so it won't break anything
- Added tests for new scenarios